### PR TITLE
fix wrong file name after renaming swift file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
       </feature>
     </config-file>
 
-    <source-file src="src/ios/LocalNetworkPermissionChecker.swift" />
+    <source-file src="src/ios/LocalNetworkPrivacy.swift" />
     <source-file src="src/ios/LocalNetworkPermission.swift" />
     <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
 


### PR DESCRIPTION
Follow up MR to #1. I missed one name change and there fore the installation fails. This MR fixes this

Tested with a beta release from this branch. And now the request works fine. 